### PR TITLE
Add subscription storefront demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tienda de Suscripciones</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <!-- Encabezado del sitio con el título y un menú de navegación básico -->
+    <header>
+        <h1>Tienda de Suscripciones</h1>
+        <nav>
+            <ul>
+                <li><a href="#">Inicio</a></li>
+                <li><a href="#">Servicios</a></li>
+                <li><a href="#">Contacto</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <!-- Sección principal donde se cargarán dinámicamente los servicios -->
+    <main>
+        <div id="product-list" class="product-grid">
+            <!-- Las tarjetas de servicio se insertarán aquí por script.js -->
+        </div>
+    </main>
+
+    <!-- Pie de página con información de derechos de autor -->
+    <footer>
+        <p>&copy; 2024 Tienda de Suscripciones. Todos los derechos reservados.</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,98 @@
+// Datos simulados de servicios digitales disponibles en la tienda
+// Cada objeto del arreglo representa un servicio con su información
+const servicios = [
+    {
+        id: 1,
+        nombre: 'ChatGPT Plus',
+        descripcion_corta: 'Acceso avanzado a IA, respuestas rápidas y generación de contenido.',
+        precio_mensual: 20,
+        url_icono_o_imagen: 'https://via.placeholder.com/150',
+        categoria: 'productividad'
+    },
+    {
+        id: 2,
+        nombre: 'Canva Pro',
+        descripcion_corta: 'Herramientas de diseño gráfico avanzado y funciones premium.',
+        precio_mensual: 12,
+        url_icono_o_imagen: 'https://via.placeholder.com/150',
+        categoria: 'productividad'
+    },
+    {
+        id: 3,
+        nombre: 'Netflix Premium',
+        descripcion_corta: 'Streaming ilimitado en alta definición y múltiples dispositivos.',
+        precio_mensual: 15,
+        url_icono_o_imagen: 'https://via.placeholder.com/150',
+        categoria: 'streaming'
+    },
+    {
+        id: 4,
+        nombre: 'HBO Max',
+        descripcion_corta: 'Acceso a series y películas exclusivas de HBO y Warner Bros.',
+        precio_mensual: 14,
+        url_icono_o_imagen: 'https://via.placeholder.com/150',
+        categoria: 'streaming'
+    },
+    {
+        id: 5,
+        nombre: 'Spotify Premium',
+        descripcion_corta: 'Escucha música sin anuncios y descarga tus canciones favoritas.',
+        precio_mensual: 10,
+        url_icono_o_imagen: 'https://via.placeholder.com/150',
+        categoria: 'streaming'
+    }
+];
+
+/**
+ * Función para crear una tarjeta HTML por cada servicio y añadirla al DOM
+ */
+function cargarServicios() {
+    const contenedor = document.getElementById('product-list');
+    servicios.forEach(servicio => {
+        // Crear elemento de tarjeta
+        const card = document.createElement('div');
+        card.classList.add('product-card');
+
+        // Imagen o icono representativo
+        const img = document.createElement('img');
+        img.src = servicio.url_icono_o_imagen;
+        img.alt = servicio.nombre;
+        card.appendChild(img);
+
+        // Nombre del servicio
+        const title = document.createElement('h3');
+        title.textContent = servicio.nombre;
+        card.appendChild(title);
+
+        // Descripción breve
+        const desc = document.createElement('p');
+        desc.textContent = servicio.descripcion_corta;
+        card.appendChild(desc);
+
+        // Precio mensual
+        const price = document.createElement('div');
+        price.classList.add('price');
+        price.textContent = `$${servicio.precio_mensual}/mes`;
+        card.appendChild(price);
+
+        // Botón para añadir al carrito
+        const button = document.createElement('button');
+        button.textContent = 'Añadir al carrito';
+        button.addEventListener('click', () => anadirAlCarrito(servicio));
+        card.appendChild(button);
+
+        // Insertar tarjeta en el contenedor
+        contenedor.appendChild(card);
+    });
+}
+
+/**
+ * Simula la acción de añadir un servicio al carrito.
+ * Por simplicidad, solo muestra una alerta en pantalla.
+ */
+function anadirAlCarrito(servicio) {
+    alert(`${servicio.nombre} añadido al carrito.`);
+}
+
+// Ejecutar la carga de servicios una vez el DOM esté listo
+window.addEventListener('DOMContentLoaded', cargarServicios);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,121 @@
+/*
+ * Estilos principales para la Tienda de Suscripciones.
+ * Se utiliza una paleta de colores suave y un layout responsivo.
+ */
+
+:root {
+    --color-principal: #2c3e50;
+    --color-secundario: #18bc9c;
+    --color-fondo: #f5f5f5;
+    --color-texto: #333333;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+body {
+    background-color: var(--color-fondo);
+    color: var(--color-texto);
+    line-height: 1.6;
+}
+
+header {
+    background-color: var(--color-principal);
+    color: #ffffff;
+    padding: 1rem;
+    text-align: center;
+}
+
+nav ul {
+    list-style: none;
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 0.5rem;
+}
+
+nav a {
+    color: #ffffff;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+nav a:hover {
+    color: var(--color-secundario);
+}
+
+main {
+    padding: 2rem;
+}
+
+.product-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+}
+
+/* Tarjeta individual de cada servicio */
+.product-card {
+    background-color: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.product-card img {
+    width: 100%;
+    height: 150px;
+    object-fit: cover;
+}
+
+.product-card h3 {
+    margin: 1rem;
+    font-size: 1.25rem;
+    color: var(--color-principal);
+}
+
+.product-card p {
+    margin: 0 1rem 1rem;
+    flex-grow: 1;
+}
+
+.product-card .price {
+    margin: 0 1rem 1rem;
+    font-weight: bold;
+    color: var(--color-secundario);
+}
+
+.product-card button {
+    margin: 1rem;
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 4px;
+    background-color: var(--color-secundario);
+    color: #ffffff;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.product-card button:hover {
+    background-color: #13967c;
+}
+
+footer {
+    background-color: var(--color-principal);
+    color: #ffffff;
+    text-align: center;
+    padding: 1rem;
+    margin-top: 2rem;
+}
+
+@media (max-width: 600px) {
+    nav ul {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
## Summary
- add `index.html` layout with header, main grid and footer
- add responsive `style.css` for product cards
- add `script.js` with sample subscription data and cart handling
- run npm and pytest (no tests)

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849f9d0bb30832ea086b282a8a660a5